### PR TITLE
feat (auth): Implement forgot password and password reset functionality

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,3 +13,12 @@ KYC_WEBHOOK_URL=https://920d-185-43-231-123.ngrok-free.app/webhook
 DIDIT_WEBHOOK_SECRET=Xnv_Jsq4hsDYvYUQ58IhY6wbWbKdx_rsMC8ljBXOOVo
 DIDIT_WORKFLOW_ID=930c712f-8e85-4ca7-b444-9b721054c648
 DIDIT_CALLBACK_URL=http://localhost:3000/login
+
+# SMTP Configuration for Nodemailer
+SMTP_HOST=sandbox.smtp.mailtrap.io
+SMTP_PORT=2525
+SMTP_SECURE=false
+SMTP_USER=05a849ad4fe45f
+SMTP_PASS=5ba1afa34b61a1
+SMTP_FROM=SmartVote
+FRONTEND_URL=http://localhost:3000

--- a/backend/controllers/auth/requestPasswordReset.js
+++ b/backend/controllers/auth/requestPasswordReset.js
@@ -5,6 +5,8 @@ const crypto = require('crypto');
 const requestPasswordReset = async (req, res) => {
   const { email } = req.body;
 
+  console.log('Password reset request for email:', email);
+
   if (!email) {
     return res.status(400).json({
       status: 'error',

--- a/backend/controllers/auth/resetPassword.js
+++ b/backend/controllers/auth/resetPassword.js
@@ -4,6 +4,8 @@ const bcrypt = require('bcrypt');
 const resetPassword = async (req, res) => {
   const { token, newPassword } = req.body;
 
+  console.log("Resetting password for token:", token);
+
   if (!token || !newPassword) {
     return res.status(400).json({
       status: 'error',

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "dotenv": "^16.4.7",
     "express-session": "^1.18.1",
     "jsonwebtoken": "^9.0.2",
+    "nodemailer": "^7.0.6",
     "pg": "^8.13.3",
     "redis": "^4.7.0",
     "ws": "^8.18.2",

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -8,6 +8,8 @@ const { logout } = require('../controllers/auth/logout.js');
 const { postApplyAdmin } = require('../controllers/auth/applyadmin.js');
 const { postUser } = require('../controllers/auth/register.js')
 const { checkSession } = require('../controllers/auth/validateUser.js');
+const { requestPasswordReset } = require('../controllers/auth/requestPasswordReset.js');
+const { resetPassword } = require('../controllers/auth/resetPassword.js');
 //user
 const { getUserByIdController } = require('../controllers/users/getUser.js');
 const {  deleteUser } = require('../controllers/users/deleteUser.js');
@@ -18,6 +20,8 @@ const { updateUserController } = require('../controllers/users/updateUser.js');
 router.post('/login', login);
 router.post('/logout', logout);
 router.get('/check-session', checkSession);
+router.post('/request-password-reset', requestPasswordReset);
+router.post('/reset-password', resetPassword);
 
 router.post('/create', postUser);
 router.get('/:userId', getUserByIdController);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,8 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import ForgotPassword from "./pages/ForgotPassword";
+import ResetPassword from "./pages/ResetPassword";
 import NotFound from "./pages/NotFound";
 import Login from "./pages/Login";
 import Signup from "./pages/Signup";
@@ -36,6 +38,8 @@ const App = () => (
             <Route path="/" element={<Index />} />
             <Route path="/login" element={<Login />} />
             <Route path="/signup" element={<Signup />} />
+            <Route path="/forgot-password" element={<ForgotPassword/>} />
+            <Route path="/reset-password" element={<ResetPassword />} />
             <Route path="/profile" element={<ProtectedRoute><Profile /></ProtectedRoute>} />
             <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
             <Route path="/admin" element={<ProtectedRoute><AdminRoute><AdminDashboard /></AdminRoute></ProtectedRoute>} />

--- a/frontend/src/api/services/authService.ts
+++ b/frontend/src/api/services/authService.ts
@@ -12,6 +12,10 @@ export interface SignupRequest {
   name: string;
 }
 
+export interface passwordResetRequest {
+  email: string;
+}
+
 export interface UserResponse {
   id: string;
   email: string;
@@ -42,7 +46,7 @@ const authService = {
    * Endpoint: POST /login
    */
   login: async (credentials: LoginRequest) => {
-    const response = await apiClient.post('/login', credentials);
+    const response = await apiClient.post('user/login', credentials);
     return response.data;
   },
 
@@ -51,7 +55,7 @@ const authService = {
    * Endpoint: POST /logout
    */
   logout: async () => {
-    const response = await apiClient.post('/logout');
+    const response = await apiClient.post('user/logout');
     return response.data;
   },
 
@@ -60,7 +64,18 @@ const authService = {
    * Endpoint: GET /check-session
    */
   checkSession: async () => {
-    const response = await apiClient.get('/check-session');
+    const response = await apiClient.get('user/check-session');
+    return response.data;
+  },
+
+  /**
+   * Send password reset request
+   * Endpoint: POST /request-password-reset
+   *
+   * @param email - The email address of the user requesting a password reset
+   */
+  requestPasswordReset: async (email: string) => {
+    const response = await apiClient.post('user/request-password-reset', { email });
     return response.data;
   },
 
@@ -70,7 +85,19 @@ const authService = {
    * Requires authentication
    */
   postApplyAdmin: async () => {
-    const response = await apiClient.post('/apply-admin');
+    const response = await apiClient.post('user/apply-admin');
+    return response.data;
+  },
+
+  /**
+   * Reset password
+   * Endpoint: POST /reset-password
+   *
+   * @param token - The password reset token
+   * @param password - The new password
+   */
+  resetPassword: async (token: string, password: string) => {
+    const response = await apiClient.post('user/reset-password', { token, newPassword: password });
     return response.data;
   },
 };

--- a/frontend/src/pages/ForgotPassword.tsx
+++ b/frontend/src/pages/ForgotPassword.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/use-toast';
+import { authService } from '@/api';
+import LoginNavbar from '@/components/LoginNavbar';
+
+const formSchema = z.object({
+  email: z.string().email({
+    message: 'Please enter a valid email address',
+  }),
+});
+
+type ForgotPasswordFormData = z.infer<typeof formSchema>;
+
+const ForgotPassword = () => {
+  const { toast } = useToast();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ForgotPasswordFormData>({
+    resolver: zodResolver(formSchema),
+  });
+
+  const onSubmit = async (data: ForgotPasswordFormData) => {
+    setIsLoading(true);
+    try {
+      await authService.requestPasswordReset(data.email);
+      setIsSuccess(true);
+      toast({
+        title: 'Password reset link sent',
+        description: 'Please check your email for further instructions.',
+        variant: 'success',
+      });
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description: 'Failed to send password reset link. Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gradient-to-b from-gray-50 to-white">
+      <LoginNavbar />
+
+      <div className="container mx-auto flex flex-1 justify-center items-center px-2">
+        <div className="flex-1 flex items-center justify-center p-8">
+          <div className="w-full max-w-md space-y-8 p-8 bg-white rounded-2xl shadow-[0_0_30px_rgba(0,0,0,0.1)] hover:shadow-[0_0_40px_rgba(0,0,0,0.15)] transition-all duration-300">
+            <div className="text-center">
+              <h2 className="text-4xl font-bold bg-gradient-to-r from-vote-blue to-vote-teal bg-clip-text text-transparent">
+                Forgot Password
+              </h2>
+              <p className="m-5 text-sm text-gray-600">
+                Enter your email address below and we'll send you a link to reset your password.
+              </p>
+              {isSuccess ? (
+                <div className="text-center text-green-600">
+                  <p>A password reset link has been sent to your email address.</p>
+                </div>
+              ) : (
+                <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+                  <div className="space-y-2">
+                    <Input
+                      id="email"
+                      type="email"
+                      placeholder="Enter your email address"
+                      className="h-12 rounded-xl border-gray-200 focus:border-vote-blue focus:ring-vote-blue/20 transition-all"
+                      {...register('email')}
+                      disabled={isLoading}
+                    />
+                    {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+                  </div>
+                  <div className="mt-6">
+                    <Button
+                      type="submit"
+                      className="w-full h-12 rounded-xl bg-gradient-to-r from-vote-blue to-vote-teal hover:opacity-90 transition-all text-white font-medium shadow-lg hover:shadow-xl"
+                      disabled={isLoading}
+                    >
+                      {isLoading ? 'Sending...' : 'Send Reset Link'}
+                    </Button>
+                  </div>
+                </form>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPassword;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -4,7 +4,7 @@ import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { TooltipContent, TooltipProvider, TooltipTrigger, Tooltip } from '@/components/ui/tooltip';
+import { TooltipContent, TooltipTrigger, Tooltip } from '@/components/ui/tooltip';
 import { useAuth } from '@/auth/AuthProvider';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -87,7 +87,7 @@ const Login = () => {
   const onSubmit = async (data: FormData) => {
     try {
       toast({
-        title: `${data?.email} and ${data?.password}`,
+        title: `${data?.email}`,
         description: 'Please wait while we log you in.',
         variant: 'default',
       });
@@ -185,7 +185,6 @@ const Login = () => {
           <form onSubmit={handleSubmit(onSubmit)} className="mt-8 space-y-6">
             <div className="space-y-4">
               {!account?.address ? (
-                <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <div>
@@ -217,7 +216,6 @@ const Login = () => {
                       <p>Please connect your account first</p>
                     </TooltipContent>
                   </Tooltip>
-                </TooltipProvider>
               ) : (
                 <div>
                   <Label htmlFor="email" className="text-gray-900 font-semibold text-base">
@@ -236,7 +234,6 @@ const Login = () => {
                 </div>
               )}
               {!account?.address ? (
-                <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <div>
@@ -275,7 +272,6 @@ const Login = () => {
                       <p>Please connect your account first</p>
                     </TooltipContent>
                   </Tooltip>
-                </TooltipProvider>
               ) : (
                 <div>
                   <Label htmlFor="password" className="text-gray-900 font-semibold text-base">

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useToast } from '@/components/ui/use-toast';
+import { authService } from '@/api';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import LoginNavbar from '@/components/LoginNavbar';
+
+const formSchema = z
+  .object({
+    password: z
+      .string()
+      .min(8, { message: 'Password must be at least 8 characters long' })
+      .regex(/[A-Z]/, { message: 'Password must contain at least one uppercase letter' })
+      .regex(/[a-z]/, { message: 'Password must contain at least one lowercase letter' })
+      .regex(/[0-9]/, { message: 'Password must contain at least one number' })
+      .regex(/[^A-Za-z0-9]/, { message: 'Password must contain at least one special character' }),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ['confirmPassword'],
+  });
+
+type ResetPasswordFormData = z.infer<typeof formSchema>;
+
+const ResetPassword = () => {
+  const { toast } = useToast();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get('token');
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ResetPasswordFormData>({
+    resolver: zodResolver(formSchema),
+  });
+
+  const onSubmit = async (data: ResetPasswordFormData) => {
+    if (!token) {
+      toast({
+        title: 'Error',
+        description: 'Invalid or missing reset token.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await authService.resetPassword(token, data.password);
+      setIsSuccess(true);
+      toast({
+        title: 'Password reset successful',
+        description: 'You can now log in with your new password.',
+        variant: 'success',
+      });
+      navigate('/login');
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description: 'Failed to reset password. Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gradient-to-b from-gray-50 to-white">
+      <LoginNavbar />
+
+      <div className="container mx-auto flex flex-1 justify-center items-center px-2">
+        <div className="flex-1 flex items-center justify-center p-8">
+          <div className="w-full max-w-md space-y-8 p-8 bg-white rounded-2xl shadow-[0_0_30px_rgba(0,0,0,0.1)] hover:shadow-[0_0_40px_rgba(0,0,0,0.15)] transition-all duration-300">
+            <div className="text-center">
+              <h2 className="text-4xl font-bold bg-gradient-to-r from-vote-blue to-vote-teal bg-clip-text text-transparent">
+                Reset Password
+              </h2>
+              <p className="m-5 text-sm text-gray-600">Enter your new password below.</p>
+              {isSuccess ? (
+                <div className="text-center text-green-600">
+                  <p>Your password has been reset successfully.</p>
+                </div>
+              ) : (
+                <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+                  <div className="space-y-2">
+                    <Label htmlFor="password">New Password</Label>
+                    <Input
+                      id="password"
+                      type="password"
+                      className="h-12 rounded-xl border-gray-200 focus:border-vote-blue focus:ring-vote-blue/20 transition-all"
+                      {...register('password')}
+                      disabled={isLoading}
+                    />
+                    {errors.password && <p className="text-red-500">{errors.password.message}</p>}
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="confirmPassword">Confirm New Password</Label>
+                    <Input
+                      id="confirmPassword"
+                      type="password"
+                      className="h-12 rounded-xl border-gray-200 focus:border-vote-blue focus:ring-vote-blue/20 transition-all"
+                      {...register('confirmPassword')}
+                      disabled={isLoading}
+                    />
+                    {errors.confirmPassword && <p className="text-red-500">{errors.confirmPassword.message}</p>}
+                  </div>
+                  <Button
+                    type="submit"
+                    className="w-full h-12 rounded-xl bg-gradient-to-r from-vote-blue to-vote-teal hover:opacity-90 transition-all text-white font-medium shadow-lg hover:shadow-xl"
+                    disabled={isLoading}
+                  >
+                    {isLoading ? 'Resetting...' : 'Reset Password'}
+                  </Button>
+                </form>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPassword;


### PR DESCRIPTION
- **Frontend:**
    - Added `ForgotPassword.tsx` page to allow users to request a password reset link.
    - Added `ResetPassword.tsx` page for users to set a new password using a token from the reset email.
    - Updated `App.tsx` to include the `/forgot-password` and `/reset-password` routes.
    - Updated `authService.ts` to include `requestPasswordReset` and `resetPassword` functions and corrected API endpoint paths.

- **Backend:**
    - Added `/request-password-reset` route to generate a token and send a reset email via SMTP.
    - Added `/reset-password` route to validate the token and update the user's password.
    - Updated `.env.example` to include the required SMTP configuration variables for email sending.
    - Added logs for both new routes.